### PR TITLE
Added "mix_url" setting to app config.

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -55,6 +55,8 @@ return [
     'url' => env('APP_URL', 'http://localhost'),
 
     'asset_url' => env('ASSET_URL', null),
+    
+    'mix_url' => env('MIX_ASSET_URL', null),    
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Mix assets that aren't served from the root path ("hostname/etc") currently can not be configured via the environment by default.